### PR TITLE
Work around PHP Floating point precision error

### DIFF
--- a/src/Order.php
+++ b/src/Order.php
@@ -75,7 +75,7 @@ class Order implements DataSource
 	{
 		$this -> id			 = $id;
 		$this -> description = $description;
-		$this -> amount		 = (int) ($amount * 100);
+		$this -> amount		 = round($amount * 100);
 
 		if ($this -> amount < 0) {
 			throw new \InvalidArgumentException('Invalid order or delivery amount');


### PR DESCRIPTION
echo (int) (4.56 * 100) == 455 ? 'Im an error!' : 'Ok';
https://secure.php.net/manual/en/language.types.float.php